### PR TITLE
Really change puppetlabs-concat version to 2.2.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,6 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <2.2.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <=2.2.0" }
   ]
 }


### PR DESCRIPTION
Commit d5000b637a63e0bc651aacf67f8d8198dad3ecaa changed to <2.2.0, which when used together with puppetlabs/concat 2.2.0 gave me the following warning:

 Warning: ModuleLoader: module 'fstab' has unresolved dependencies - it will only see those that are resolved.

when changing to ">=1.1.2 <=2.2.0"

the warning went away.